### PR TITLE
Added single column to X-Dog fit SamplePlatform template correctly

### DIFF
--- a/indexer/src/main/java/org/pdxfinder/dataexport/UniversalDataExporter.java
+++ b/indexer/src/main/java/org/pdxfinder/dataexport/UniversalDataExporter.java
@@ -742,6 +742,7 @@ public class UniversalDataExporter {
 
                 List<String> dataRow = new ArrayList<>();
 
+                dataRow.add("");
                 dataRow.add(model.getSample().getSourceSampleId());
                 dataRow.add(patientOrigin);
                 dataRow.add("NA");
@@ -788,6 +789,7 @@ public class UniversalDataExporter {
 
                     List<String> dataRow = new ArrayList<>();
 
+                    dataRow.add("");
                     dataRow.add(sample.getSourceSampleId());
                     dataRow.add("xenograft");
                     dataRow.add(passage);


### PR DESCRIPTION
added a single empty string to first to list used to generate rows in SamplePlatform template.

Because:
The template starts with a blank box and previously this was not accounted for.