### PR TITLE
Remove data model

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -26,6 +26,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.pdxfinder</groupId>
+            <artifactId>data-model</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/data-services/pom.xml
+++ b/data-services/pom.xml
@@ -73,7 +73,7 @@
         </dependency>
         <dependency>
             <groupId>org.pdxfinder</groupId>
-            <artifactId>Data-Model</artifactId>
+            <artifactId>data-model</artifactId>
             <version>1.0.0</version>
             <scope>compile</scope>
         </dependency>

--- a/indexer/pom.xml
+++ b/indexer/pom.xml
@@ -21,6 +21,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.pdxfinder</groupId>
+            <artifactId>data-model</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,14 +23,6 @@
         <module>admin</module>
     </modules>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.pdxfinder</groupId>
-            <artifactId>Data-Model</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
-        </dependency>
-    </dependencies>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -21,6 +21,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.pdxfinder</groupId>
+            <artifactId>data-model</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>


### PR DESCRIPTION
Fixing changes to broken POM dependencies. Lower cased "Data-Model". Removed dependency from parent and added to children. Tested by deleting and reporting the jars find in ~/.m2/respository/org/pdxfinder