### PR TITLE
Lower case and trimmed

### DIFF
--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/TableSetCleaner.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/TableSetCleaner.java
@@ -3,6 +3,8 @@ package org.pdxfinder.dataloaders.updog;
 import org.springframework.stereotype.Service;
 import tech.tablesaw.api.Table;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -14,6 +16,10 @@ public class TableSetCleaner {
         TableSetUtilities.removeDescriptionColumn(pdxTableSet);
         pdxTableSet = TableSetUtilities.removeHeaderRows(pdxTableSet);
         pdxTableSet = TableSetUtilities.removeBlankRows(pdxTableSet);
+        List<String> columnsExceptFromDeepCleaning = Arrays.
+                asList("model_id", "sample_id","patient_id", "name", "validation_host_strain_full", "provider_name",
+                        "name", "abbreviation", "internal_url", "internal_dosing_url");
+        pdxTableSet = TableSetUtilities.cleanValues(pdxTableSet, columnsExceptFromDeepCleaning);
         return pdxTableSet;
     }
 

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/TableSetUtilities.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/TableSetUtilities.java
@@ -3,8 +3,12 @@ package org.pdxfinder.dataloaders.updog;
 import org.apache.commons.lang3.StringUtils;
 import tech.tablesaw.api.Table;
 
-import java.util.*;
-import java.util.stream.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class TableSetUtilities {
 
@@ -58,6 +62,15 @@ public class TableSetUtilities {
                 e -> e.getValue().setName(substringAfterIfContainsSeparator(e.getKey(), "_"))
             ));
     }
+
+    static Map<String, Table> cleanValues(Map<String, Table> tableSet, List<String> exceptionColumns) {
+        return tableSet.entrySet().stream().collect(
+                Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> TableUtilities.cleanTableValues(e.getValue(), e.getValue().name(), exceptionColumns)
+                ));
+    }
+
 
     static String substringAfterIfContainsSeparator(String string, String separator) {
         return string.contains(separator)

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/TableUtilities.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/TableUtilities.java
@@ -5,11 +5,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
+import tech.tablesaw.columns.Column;
 import tech.tablesaw.io.csv.CsvReadOptions;
 import tech.tablesaw.selection.Selection;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public final class TableUtilities {
 
@@ -44,6 +48,42 @@ public final class TableUtilities {
             : table.dropRange(numberOfRows);
     }
 
+    public static Table cleanTableValues(Table table, String talbeName, List<String> columnExceptions){
+        Table lowerCasedTable = lowerCaseSelectColumnValues(table, columnExceptions);
+        Table cleanedTable = trimColumnValues(lowerCasedTable);
+        cleanedTable.setName(talbeName);
+        return cleanedTable;
+    }
+
+    private static Table trimColumnValues(Table table){
+        List<String> columnNames = table.columnNames();
+        Table transformedTable = Table.create(table.columns().stream()
+                .map(x -> x.asStringColumn().trim())
+                .collect(Collectors.toList())
+        );
+        return renameColumnsInTable(transformedTable, columnNames);
+    }
+
+    public static Table lowerCaseSelectColumnValues(Table table, List<String> columnExceptions){
+        List<String> columnNames = table.columnNames();
+        List<Column<?>> transformedColumns = new ArrayList<>();
+        for(Column<?> column: table.columns()){
+            if (!columnExceptions.contains(column.name())) {
+                Column<String> lowerCasedColumn = column.asStringColumn().lowerCase();
+                transformedColumns.add(lowerCasedColumn);
+            }
+            else{ transformedColumns.add(column); }
+        }
+        return renameColumnsInTable(Table.create(transformedColumns), columnNames);
+    }
+
+    private static Table renameColumnsInTable(Table table, List<String> newNames){
+        for(int i=0; i < newNames.size(); i++){
+            table.column(i).setName(newNames.get(i));
+        }
+        return table;
+    }
+
     private static boolean doesNotHaveEnoughRows(Table table, int numberOfRows) {
         return table.rowCount() <= numberOfRows;
     }
@@ -56,6 +96,7 @@ public final class TableUtilities {
     public static Table removeRowsMissingRequiredColumnValue(Table table, StringColumn requiredColumn) {
         return removeRowsMissingRequiredColumnValue(table, requiredColumn.name());
     }
+
 
     public static Table fromString(String tableName, String ... lines) {
         Table table = Table.create();

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/domainobjectcreation/DomainObjectCreator.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/domainobjectcreation/DomainObjectCreator.java
@@ -104,9 +104,9 @@ public class DomainObjectCreator {
         log.info("Creating provider");
         Table finderRelatedTable = pdxDataTables.get("metadata-loader.tsv");
         Row row = finderRelatedTable.row(0);
-        String providerName = row.getString(TSV.Metadata.name.name());
-        String abbrev = row.getString(TSV.Metadata.abbreviation.name());
-        String internalUrl = row.getString(TSV.Metadata.internal_url.name());
+        String providerName = getCellAsText(row,TSV.Metadata.name.name());
+        String abbrev = getCellAsText(row,TSV.Metadata.abbreviation.name());
+        String internalUrl = getCellAsText(row,TSV.Metadata.internal_url.name());
         Group providerGroup = dataImportService.getProviderGroup(
                 providerName, abbrev, "", "", "", internalUrl);
         addDomainObject(PROVIDER_GROUPS, FIRST, providerGroup);
@@ -118,15 +118,15 @@ public class DomainObjectCreator {
         for (Row row : patientTable) {
             try {
                 Patient patient = dataImportService.createPatient(
-                        row.getText(TSV.Metadata.patient_id.name()),
+                        getCellAsText(row,TSV.Metadata.patient_id.name()),
                         (Group) getDomainObject(TSV.Metadata.provider_group.name(), FIRST),
-                        row.getText(TSV.Metadata.sex.name()),
+                        getCellAsText(row,TSV.Metadata.sex.name()),
                         "",
-                        row.getText(TSV.Metadata.ethnicity.name()));
+                        getCellAsText(row,TSV.Metadata.ethnicity.name()));
 
-                patient.setCancerRelevantHistory(row.getText(TSV.Metadata.history.name()));
-                patient.setFirstDiagnosis(row.getText(TSV.Metadata.initial_diagnosis.name()));
-                patient.setAgeAtFirstDiagnosis(row.getText(TSV.Metadata.age_at_initial_diagnosis.name()));
+                patient.setCancerRelevantHistory(getCellAsText(row, TSV.Metadata.history.name()));
+                patient.setFirstDiagnosis(getCellAsText(row,TSV.Metadata.initial_diagnosis.name()));
+                patient.setAgeAtFirstDiagnosis(getCellAsText(row, TSV.Metadata.age_at_initial_diagnosis.name()));
 
                 addDomainObject(
                     PATIENTS,
@@ -148,13 +148,13 @@ public class DomainObjectCreator {
         for (Row row : sampleTable) {
             String patientId = getCellAsText(row, TSV.Metadata.patient_id.name());
             String modelId = getCellAsText(row, TSV.Metadata.model_id.name());
-            String dateOfCollection = row.getString(TSV.Metadata.collection_date.name());
+            String dateOfCollection = getCellAsText(row, TSV.Metadata.collection_date.name());
             String ageAtCollection = getCellAsText(row, TSV.Metadata.age_in_years_at_collection.name());
             String collectionEvent = getCellAsText(row, TSV.Metadata.collection_event.name());
             String elapsedTime = getCellAsText(row, TSV.Metadata.months_since_collection_1.name());
-            String primarySiteName = row.getString(TSV.Metadata.primary_site.name());
-            String virologyStatus = row.getString(TSV.Metadata.virology_status.name());
-            String treatmentNaive = row.getString(TSV.Metadata.treatment_naive_at_collection.name());
+            String primarySiteName = getCellAsText(row,TSV.Metadata.primary_site.name());
+            String virologyStatus = getCellAsText(row,TSV.Metadata.virology_status.name());
+            String treatmentNaive = getCellAsText(row,TSV.Metadata.treatment_naive_at_collection.name());
 
             Patient patient = (Patient) getDomainObject(PATIENTS, patientId);
             if (patient == null) {
@@ -199,7 +199,7 @@ public class DomainObjectCreator {
         Group providerGroup = (Group) domainObjects.get(PROVIDER_GROUPS).get(FIRST);
         for (Row row : modelTable) {
             String modelId = getCellAsText(row, TSV.Metadata.model_id.name());
-            String hostStrainNomenclature = row.getString(TSV.Metadata.host_strain_full.name());
+            String hostStrainNomenclature = getCellAsText(row,TSV.Metadata.host_strain_full.name());
             String passageString = getCellAsText(row, TSV.Metadata.passage_number.name());
             String publications = getCellAsText(row, TSV.Metadata.publications.name());
 
@@ -230,10 +230,10 @@ public class DomainObjectCreator {
         Table modelValidationTable = pdxDataTables.get("metadata-model_validation.tsv");
         for (Row row : modelValidationTable) {
             String modelId = getCellAsText(row, TSV.Metadata.model_id.name());
-            String validationTechnique = row.getString(TSV.Metadata.validation_technique.name());
-            String description = row.getString(TSV.Metadata.description.name());
+            String validationTechnique = getCellAsText(row,TSV.Metadata.validation_technique.name());
+            String description = getCellAsText(row,TSV.Metadata.description.name());
             String passagesTested = getCellAsText(row, TSV.Metadata.passages_tested.name());
-            String hostStrainFull = row.getString(TSV.Metadata.validation_host_strain_full.name());
+            String hostStrainFull = getCellAsText(row,TSV.Metadata.validation_host_strain_full.name());
 
             ModelCreation modelCreation = (ModelCreation) getDomainObject(MODELS, modelId);
             if (modelCreation != null)
@@ -263,13 +263,13 @@ public class DomainObjectCreator {
 
         for (Row row : sharingTable) {
             String modelId = getCellAsText(row, TSV.Metadata.model_id.name());
-            String providerType = row.getString(TSV.Metadata.provider_type.name());
-            String accessibility = row.getString(TSV.Metadata.accessibility.name());
-            String europdxAccessModality = row.getString(TSV.Metadata.europdx_access_modality.name());
-            String email = row.getString(TSV.Metadata.email.name());
-            String formUrl = row.getString(TSV.Metadata.form_url.name());
-            String databaseUrl = row.getString(TSV.Metadata.database_url.name());
-            String project = row.getString(TSV.Metadata.project.name());
+            String providerType = getCellAsText(row,TSV.Metadata.provider_type.name());
+            String accessibility = getCellAsText(row,TSV.Metadata.accessibility.name());
+            String europdxAccessModality = getCellAsText(row,TSV.Metadata.europdx_access_modality.name());
+            String email = getCellAsText(row,TSV.Metadata.email.name());
+            String formUrl = getCellAsText(row,TSV.Metadata.form_url.name());
+            String databaseUrl = getCellAsText(row,TSV.Metadata.database_url.name());
+            String project = getCellAsText(row,TSV.Metadata.project.name());
 
             ModelCreation modelCreation = (ModelCreation) getDomainObject(MODELS, modelId);
             if (modelCreation == null) throw new NullPointerException();
@@ -301,11 +301,11 @@ public class DomainObjectCreator {
         for (Row row : samplePlatformTable) {
 
             String sampleId = getCellAsText(row, TSV.SamplePlatform.sample_id.name());
-            String sampleOrigin = row.getString(TSV.SamplePlatform.sample_origin.name());
-            String platformName = row.getString(TSV.SamplePlatform.platform.name());
-            String molCharType = row.getString(TSV.SamplePlatform.molecular_characterisation_type.name());
-            String rawDataUrl = formatAccessionToURL(row.getString(TSV.SamplePlatform.raw_data_file.name()));
-            String platformUrl = row.getString(TSV.SamplePlatform.internal_protocol_url.name());
+            String sampleOrigin = getCellAsText(row,TSV.SamplePlatform.sample_origin.name());
+            String platformName = getCellAsText(row,TSV.SamplePlatform.platform.name());
+            String molCharType = getCellAsText(row,TSV.SamplePlatform.molecular_characterisation_type.name());
+            String rawDataUrl = formatAccessionToURL(getCellAsText(row,TSV.SamplePlatform.raw_data_file.name()));
+            String platformUrl = getCellAsText(row,TSV.SamplePlatform.internal_protocol_url.name());
 
             Sample sample = null;
 
@@ -490,8 +490,8 @@ public class DomainObjectCreator {
     private MolecularCharacterization getMolcharByType(Row row, String molCharType) {
 
         String sampleId = getCellAsText(row, "sample_id");
-        String sampleOrigin = row.getString("sample_origin");
-        String platformName = row.getString(PLATFORMS);
+        String sampleOrigin = getCellAsText(row,"sample_origin");
+        String platformName = getCellAsText(row,PLATFORMS);
         Sample sample = null;
 
         if (sampleOrigin.equalsIgnoreCase("patient")) {
@@ -534,7 +534,7 @@ public class DomainObjectCreator {
     private Specimen getOrCreateSpecimen(Row row) {
         // For Mutation
         String modelId = getCellAsText(row, TSV.Mutation.model_id.name());
-        String hostStrainSymbol = row.getString(TSV.Mutation.host_strain_nomenclature.name());
+        String hostStrainSymbol = getCellAsText(row,TSV.Mutation.host_strain_nomenclature.name());
         String passage = getCellAsText(row, TSV.Mutation.passage.name());
         if(hostStrainSymbol.equals("")) hostStrainSymbol = NOT_SPECIFIED;
         String sampleId = getCellAsText(row, TSV.Mutation.sample_id.name());
@@ -738,11 +738,11 @@ public class DomainObjectCreator {
 
     private Specimen createSpecimen(Row row, String passage) {
 
-        String hostStrainName = row.getString(TSV.Metadata.host_strain.name());
-        String hostStrainNomenclature = row.getString(TSV.Metadata.host_strain_full.name());
-        String engraftmentSiteName = row.getString(TSV.Metadata.engraftment_site.name());
-        String engraftmentTypeName = row.getString(TSV.Metadata.engraftment_type.name());
-        String sampleType = row.getString(TSV.Metadata.sample_type.name());
+        String hostStrainName = getCellAsText(row,TSV.Metadata.host_strain.name());
+        String hostStrainNomenclature = getCellAsText(row,TSV.Metadata.host_strain_full.name());
+        String engraftmentSiteName = getCellAsText(row,TSV.Metadata.engraftment_site.name());
+        String engraftmentTypeName = getCellAsText(row,TSV.Metadata.engraftment_type.name());
+        String sampleType = getCellAsText(row,TSV.Metadata.sample_type.name());
         String passageNum = passage.trim();
 
         HostStrain hostStrain = getOrCreateHostStrain(hostStrainName, hostStrainNomenclature);
@@ -805,15 +805,15 @@ public class DomainObjectCreator {
 
     private Sample createPatientSample(Row row) {
 
-        String diagnosis = row.getString(TSV.Metadata.diagnosis.name());
+        String diagnosis = getCellAsText(row,TSV.Metadata.diagnosis.name());
         String sampleId = getCellAsText(row, TSV.Metadata.sample_id.name());
-        String tumorTypeName = row.getString(TSV.Metadata.tumour_type.name());
-        String primarySiteName = row.getString(TSV.Metadata.primary_site.name());
-        String collectionSiteName = row.getString(TSV.Metadata.collection_site.name());
+        String tumorTypeName = getCellAsText(row,TSV.Metadata.tumour_type.name());
+        String primarySiteName = getCellAsText(row,TSV.Metadata.primary_site.name());
+        String collectionSiteName = getCellAsText(row,TSV.Metadata.collection_site.name());
         String stage = getCellAsText(row, TSV.Metadata.stage.name());
-        String stagingSystem = row.getString(TSV.Metadata.staging_system.name());
+        String stagingSystem = getCellAsText(row,TSV.Metadata.staging_system.name());
         String grade = getCellAsText(row, TSV.Metadata.grade.name());
-        String gradingSystem = row.getString(TSV.Metadata.grading_system.name());
+        String gradingSystem = getCellAsText(row,TSV.Metadata.grading_system.name());
 
         Tissue primarySite = getOrCreateTissue(primarySiteName);
         Tissue collectionSite = getOrCreateTissue(collectionSiteName);
@@ -1001,10 +1001,10 @@ public class DomainObjectCreator {
 
     private TreatmentProtocol getTreatmentProtocol(Row row){
 
-        String drugString = row.getString(TSV.Treatment.treatment_name.name());
+        String drugString = getCellAsText(row,TSV.Treatment.treatment_name.name());
         String doseString = getCellAsText(row, TSV.Treatment.treatment_dose.name());
-        String responseString = row.getString(TSV.Treatment.treatment_response.name());
-        String responseClassificationString = row.getString(TSV.Treatment.response_classification.name());
+        String responseString = getCellAsText(row,TSV.Treatment.treatment_response.name());
+        String responseClassificationString = getCellAsText(row,TSV.Treatment.response_classification.name());
         String[] drugArray = drugString.split("\\+");
         String[] doseArray = doseString.split(";");
 
@@ -1051,6 +1051,8 @@ public class DomainObjectCreator {
                 return Double.toString(row.getDouble(columnName));
             } else if (row.getColumnType(columnName) == ColumnType.INTEGER) {
                 return Integer.toString(row.getInt(columnName));
+            } else if (row.getColumnType(columnName) == ColumnType.LOCAL_DATE) {
+                return row.getDate(columnName).toString();
             }
             else {
                 throw new IllegalArgumentException(

--- a/indexer/src/test/java/org/pdxfinder/dataloaders/updog/TableSetUtilitiesTest.java
+++ b/indexer/src/test/java/org/pdxfinder/dataloaders/updog/TableSetUtilitiesTest.java
@@ -3,13 +3,11 @@ package org.pdxfinder.dataloaders.updog;
 import org.junit.Test;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
+import tech.tablesaw.columns.Column;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.pdxfinder.dataloaders.updog.TableSetUtilities.*;
 
 public class TableSetUtilitiesTest {
@@ -128,6 +126,33 @@ public class TableSetUtilitiesTest {
             expected.toString(),
             removeProviderNameFromFilename(expected).toString()
         );
+    }
+
+    @Test public void cleanSpacesAndLowerCase_givenTable_clean() {
+        String exceptionColumn = "exception_column";
+        List<Column<?>> tableColumns = Arrays.asList(
+                StringColumn.create("column_1", Arrays.asList(" PADDEDSTRING ", " PADDEDSTRING_1 ")),
+                StringColumn.create(exceptionColumn, Arrays.asList(" PADDEDSTRING ", " PADDEDSTRING_1 "))
+        );
+        List<Column<?>> expectedTableColumns = Arrays.asList(
+                StringColumn.create("column_1", Arrays.asList("paddedstring", "paddedstring_1")),
+                StringColumn.create(exceptionColumn, Arrays.asList("PADDEDSTRING", "PADDEDSTRING_1"))
+        );
+        Map<String, Table> tableSet = new HashMap<>();
+        Map<String, Table> expectedTableSet = new HashMap<>();
+        Arrays.asList("table_1.tsv", "table_2.tsv").forEach(
+                s -> tableSet.put(s, Table.create(s, tableColumns
+                        )));
+        Arrays.asList("table_1.tsv", "table_2.tsv").forEach(
+                s -> expectedTableSet.put(s, Table.create(s, expectedTableColumns
+                )));
+
+        assertEquals(
+                expectedTableSet.toString(),
+                cleanValues(tableSet, Collections.singletonList(exceptionColumn)).toString()
+
+        );
+
     }
 
 }

--- a/indexer/src/test/java/org/pdxfinder/dataloaders/updog/TableUtilitiesTest.java
+++ b/indexer/src/test/java/org/pdxfinder/dataloaders/updog/TableUtilitiesTest.java
@@ -5,10 +5,10 @@ import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
-import static org.pdxfinder.dataloaders.updog.TableUtilities.removeHeaderRows;
-import static org.pdxfinder.dataloaders.updog.TableUtilities.removeRowsMissingRequiredColumnValue;
+import static org.pdxfinder.dataloaders.updog.TableUtilities.*;
 
 public class TableUtilitiesTest {
 
@@ -47,6 +47,38 @@ public class TableUtilitiesTest {
             removeHeaderRows(table, 1).toString()
         );
     }
+
+    @Test public void removeSpacesAndLowerCase_GivenAColumnWithPaddingSpacesAndUppercase_returnsCleanedStrings(){
+        Table table = Table.create().addColumns(
+                StringColumn.create("column_1", Arrays.asList(" PADDEDSTRING ", " PADDEDSTRING_1 ")));
+        Table expected = Table.create().addColumns(
+                StringColumn.create("column_1", Arrays.asList("paddedstring", "paddedstring_1")));
+
+        assertEquals(
+               expected.toString(),
+               cleanTableValues(table, table.name(), Collections.singletonList("")).toString()
+        );
+    }
+
+    @Test public void doNotCleanExceptionColumns_GivenATableWithTwoColumns_returnsUncleanedExceptions(){
+        String exceptionColumn = "exception_column";
+        Table table = Table.create().addColumns(
+                StringColumn.create("column_1", Arrays.asList(" PADDEDSTRING ", " PADDEDSTRING_1 ")),
+                StringColumn.create(exceptionColumn, Arrays.asList(" PADDEDSTRING ", " PADDEDSTRING_1 ")
+                ));
+        Table expected = Table.create().addColumns(
+                StringColumn.create("column_1", Arrays.asList("paddedstring", "paddedstring_1")),
+                StringColumn.create(exceptionColumn, Arrays.asList("PADDEDSTRING", "PADDEDSTRING_1")
+                ));
+
+        assertEquals(
+                expected.toString(),
+                cleanTableValues(table, table.name(), Collections.singletonList(exceptionColumn)).toString()
+        );
+    }
+
+
+
 
     @Test public void removeHeaderRows_givenTableWithTypicalHeader_removesHeaderRows() {
         Table expected = Table.create().addColumns(
@@ -143,5 +175,4 @@ public class TableUtilitiesTest {
             table2.toString()
         );
     }
-
 }


### PR DESCRIPTION
Added lower casing and space trimming to tableSetCleaner which will effect the metadata and sample-platform sheets. All columns are trimmed. However the following columns are except from lower casing: model_id", "sample_id","patient_id", "name", "validation_host_strain_full", "provider_name",  "name", "provider_abbreviation", "project", "internal_url", "internal_dosing_url". This does not include updated styles to the front end.

All new features are tested.

Also, fixes bug in jtablesaw that was encountered in the DomainObjectLoader when loading the Jax API datasets.