### PR TITLE
Validator relation rules

### DIFF
--- a/data-services/src/main/java/org/pdxfinder/services/OmicTransformationService.java
+++ b/data-services/src/main/java/org/pdxfinder/services/OmicTransformationService.java
@@ -27,7 +27,7 @@ public class OmicTransformationService {
     private Map<String, String> geneIdCache = new HashMap<>();
 
     public void convertListOfNcbiToHgnc(List<String> geneList){
-        String fileOut = "ncbiToHugoAccesions";
+        String fileOut = "ncbiToHugoAccessions";
 
         FileWriter fstream = null;
         try {

--- a/data-services/src/test/java/org/pdxfinder/services/omicTransformationServiceTest.java
+++ b/data-services/src/test/java/org/pdxfinder/services/omicTransformationServiceTest.java
@@ -1,5 +1,6 @@
 package org.pdxfinder.services;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,6 +9,7 @@ import org.mockito.Mock;
 import org.pdxfinder.BaseTest;
 import org.pdxfinder.graph.dao.Marker;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,6 +30,12 @@ public class omicTransformationServiceTest extends BaseTest {
     public void init(){
         marker = new Marker();
         marker.setHgncSymbol("TEST");
+    }
+
+    @After
+    public void clean(){
+      File resultingFile = new File("ncbiToHugoAccessions");
+      resultingFile.delete();
     }
 
     @Test

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/TableSetCleaner.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/TableSetCleaner.java
@@ -11,15 +11,24 @@ import java.util.Map;
 public class TableSetCleaner {
 
     public Map<String, Table> cleanPdxTables(Map<String, Table> pdxTableSet) {
+        List<String> columnsExceptFromLowercasing = Arrays.asList(
+                "model_id",
+                "sample_id",
+                "patient_id",
+                "name",
+                "validation_host_strain_full",
+                "provider_name",
+                "provider_abbreviation",
+                "project",
+                "internal_url",
+                "internal_dosing_url"
+        );
         pdxTableSet = TableSetUtilities.removeProviderNameFromFilename(pdxTableSet);
         pdxTableSet.remove("metadata-checklist.tsv");
         TableSetUtilities.removeDescriptionColumn(pdxTableSet);
         pdxTableSet = TableSetUtilities.removeHeaderRows(pdxTableSet);
         pdxTableSet = TableSetUtilities.removeBlankRows(pdxTableSet);
-        List<String> columnsExceptFromDeepCleaning = Arrays.
-                asList("model_id", "sample_id","patient_id", "name", "validation_host_strain_full", "provider_name",
-                        "name", "provider_abbreviation", "project", "internal_url", "internal_dosing_url");
-        pdxTableSet = TableSetUtilities.cleanValues(pdxTableSet, columnsExceptFromDeepCleaning);
+        pdxTableSet = TableSetUtilities.cleanValues(pdxTableSet, columnsExceptFromLowercasing);
         return pdxTableSet;
     }
 

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/TableSetCleaner.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/TableSetCleaner.java
@@ -18,7 +18,7 @@ public class TableSetCleaner {
         pdxTableSet = TableSetUtilities.removeBlankRows(pdxTableSet);
         List<String> columnsExceptFromDeepCleaning = Arrays.
                 asList("model_id", "sample_id","patient_id", "name", "validation_host_strain_full", "provider_name",
-                        "name", "abbreviation", "internal_url", "internal_dosing_url");
+                        "name", "provider_abbreviation", "project", "internal_url", "internal_dosing_url");
         pdxTableSet = TableSetUtilities.cleanValues(pdxTableSet, columnsExceptFromDeepCleaning);
         return pdxTableSet;
     }

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/Updog.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/Updog.java
@@ -88,6 +88,7 @@ public class Updog {
             omicSpecifications
         );
         combinedValidationRuleset.setProvider(provider);
+        validator.resetErrors();
         return validator.validate(tableSet, combinedValidationRuleset);
     }
 

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/domainobjectcreation/DomainObjectCreator.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/domainobjectcreation/DomainObjectCreator.java
@@ -178,7 +178,6 @@ public class DomainObjectCreator {
                 patientSnapshot.setTreatmentNaive(treatmentNaive);
                 patient.addSnapshot(patientSnapshot);
             }
-
             Sample sample = createPatientSample(row);
             sample.setDataSource(providerGroup.getAbbreviation());
             patientSnapshot.addSample(sample);
@@ -250,8 +249,6 @@ public class DomainObjectCreator {
                 log.error("Can't link validation, missing model {}",modelId);
                 //throw new NullPointerException();
             }
-
-
         }
     }
 

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/OmicValidationRuleset.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/OmicValidationRuleset.java
@@ -137,7 +137,7 @@ public class OmicValidationRuleset extends ValidationRuleCreator {
             essentialCytogeneticsColumns
         );
 
-        Relation relations = Relation.between(
+        Relation relations = Relation.betweenTableKeys(
             ColumnReference.of("metadata-model.tsv", "model_id"),
             ColumnReference.of(tableName, "model_id"));
 

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/PdxValidationRuleset.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/PdxValidationRuleset.java
@@ -137,9 +137,6 @@ public class PdxValidationRuleset extends ValidationRuleCreator {
                     ColumnReference.of("metadata-model.tsv", "model_id")),
                 Relation.betweenTableKeys(
                     ColumnReference.of("metadata-model.tsv", "model_id"),
-                    ColumnReference.of("metadata-model_validation.tsv", "model_id")),
-                Relation.betweenTableKeys(
-                    ColumnReference.of("metadata-model.tsv", "model_id"),
                     ColumnReference.of("metadata-sharing.tsv", "model_id")),
                 Relation.betweenTableKeys(
                     ColumnReference.of("metadata-model.tsv", "model_id"),

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/PdxValidationRuleset.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/PdxValidationRuleset.java
@@ -27,6 +27,8 @@ public class PdxValidationRuleset extends ValidationRuleCreator {
             "age_at_initial_diagnosis"
         ).forEach(s -> tableColumns.add(ColumnReference.of("metadata-patient.tsv", s)));
         Arrays.asList(
+            "patient_id",
+            "sample_id",
             "collection_date",
             "collection_event",
             "months_since_collection_1",
@@ -43,9 +45,11 @@ public class PdxValidationRuleset extends ValidationRuleCreator {
             "sharable",
             "treatment_naive_at_collection",
             "treated",
-            "prior_treatment"
+            "prior_treatment",
+            "model_id"
         ).forEach(s -> tableColumns.add(ColumnReference.of("metadata-sample.tsv", s)));
         Arrays.asList(
+            "model_id",
             "host_strain",
             "host_strain_full",
             "engraftment_site",
@@ -56,13 +60,13 @@ public class PdxValidationRuleset extends ValidationRuleCreator {
             "publications"
         ).forEach(s -> tableColumns.add(ColumnReference.of("metadata-model.tsv", s)));
         Arrays.asList(
-            "model_id",
             "validation_technique",
             "description",
             "passages_tested",
             "validation_host_strain_full"
         ).forEach(s -> tableColumns.add(ColumnReference.of("metadata-model_validation.tsv", s)));
         Arrays.asList(
+            "model_id",
             "provider_type",
             "accessibility",
             "europdx_access_modality",
@@ -92,6 +96,10 @@ public class PdxValidationRuleset extends ValidationRuleCreator {
             .collect(Collectors.toSet());
 
         Set<ColumnReference> idColumns = matchingColumnsFromAnyTable(columnReferences, "_id");
+        Set<ColumnReference> uniqIdColumns = new HashSet<>();
+        uniqIdColumns.addAll(matchingColumnsFromTable(columnReferences, "metadata-patient.tsv", new String[]{"patient_id"}));
+        uniqIdColumns.addAll(matchingColumnsFromTable(columnReferences, "metadata-sharing.tsv", new String[]{"model_id"}));
+
         Set<ColumnReference> hostStrainColumns = matchingColumnsFromAnyTable(columnReferences, "host_strain");
 
         Set<ColumnReference> essentialSampleColumns = matchingColumnsFromTable(columnReferences, "sample",
@@ -119,7 +127,7 @@ public class PdxValidationRuleset extends ValidationRuleCreator {
             .addRequiredTables(metadataTables)
             .addRequiredColumns(essentialColumns)
             .addNonEmptyColumns(essentialColumns)
-            .addUniqueColumns(idColumns)
+            .addUniqueColumns(uniqIdColumns)
             .addRelations(new HashSet<>(Arrays.asList(
                 Relation.betweenTableKeys(
                     ColumnReference.of("metadata-patient.tsv", "patient_id" ),

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/PdxValidationRuleset.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/PdxValidationRuleset.java
@@ -126,22 +126,34 @@ public class PdxValidationRuleset extends ValidationRuleCreator {
             .addNonEmptyColumns(essentialColumns)
             .addUniqueColumns(idColumns)
             .addRelations(new HashSet<>(Arrays.asList(
-                Relation.between(
-                    ColumnReference.of("metadata-patient.tsv", "patient_id"),
+                Relation.betweenTableKeys(
+                    ColumnReference.of("metadata-patient.tsv", "patient_id" ),
                     ColumnReference.of("metadata-sample.tsv", "patient_id")),
-                Relation.between(
+                Relation.betweenTableKeys(
                     ColumnReference.of("metadata-sample.tsv", "model_id"),
                     ColumnReference.of("metadata-model.tsv", "model_id")),
-                Relation.between(
+                Relation.betweenTableKeys(
                     ColumnReference.of("metadata-model.tsv", "model_id"),
                     ColumnReference.of("metadata-model_validation.tsv", "model_id")),
-                Relation.between(
+                Relation.betweenTableKeys(
                     ColumnReference.of("metadata-model.tsv", "model_id"),
                     ColumnReference.of("metadata-sharing.tsv", "model_id")),
-                Relation.between(
+                Relation.betweenTableKeys(
                     ColumnReference.of("metadata-model.tsv", "model_id"),
-                    ColumnReference.of("sampleplatform-data.tsv", "model_id")
-                )
+                    ColumnReference.of("sampleplatform-data.tsv", "model_id")),
+                Relation.betweenTableColumns(
+                        Relation.validityType.one_to_many,
+                        ColumnReference.of("metadata-sample.tsv", "sample_id"),
+                        ColumnReference.of("metadata-sample.tsv", "patient_id")
+                        ),
+                Relation.betweenTableColumns(
+                        Relation.validityType.one_to_one,
+                        ColumnReference.of("metadata-sample.tsv", "patient_id"),
+                        ColumnReference.of("metadata-sample.tsv", "model_id")),
+                Relation.betweenTableColumns(
+                        Relation.validityType.one_to_one,
+                        ColumnReference.of("metadata-sample.tsv", "sample_id"),
+                        ColumnReference.of("metadata-sample.tsv", "model_id"))
             )))
             .setProvider(provider);
     }

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/PdxValidationRuleset.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/PdxValidationRuleset.java
@@ -27,8 +27,6 @@ public class PdxValidationRuleset extends ValidationRuleCreator {
             "age_at_initial_diagnosis"
         ).forEach(s -> tableColumns.add(ColumnReference.of("metadata-patient.tsv", s)));
         Arrays.asList(
-            "patient_id",
-            "sample_id",
             "collection_date",
             "collection_event",
             "months_since_collection_1",
@@ -45,11 +43,9 @@ public class PdxValidationRuleset extends ValidationRuleCreator {
             "sharable",
             "treatment_naive_at_collection",
             "treated",
-            "prior_treatment",
-            "model_id"
+            "prior_treatment"
         ).forEach(s -> tableColumns.add(ColumnReference.of("metadata-sample.tsv", s)));
         Arrays.asList(
-            "model_id",
             "host_strain",
             "host_strain_full",
             "engraftment_site",
@@ -67,7 +63,6 @@ public class PdxValidationRuleset extends ValidationRuleCreator {
             "validation_host_strain_full"
         ).forEach(s -> tableColumns.add(ColumnReference.of("metadata-model_validation.tsv", s)));
         Arrays.asList(
-            "model_id",
             "provider_type",
             "accessibility",
             "europdx_access_modality",
@@ -146,10 +141,6 @@ public class PdxValidationRuleset extends ValidationRuleCreator {
                         ColumnReference.of("metadata-sample.tsv", "sample_id"),
                         ColumnReference.of("metadata-sample.tsv", "patient_id")
                         ),
-                Relation.betweenTableColumns(
-                        Relation.validityType.one_to_one,
-                        ColumnReference.of("metadata-sample.tsv", "patient_id"),
-                        ColumnReference.of("metadata-sample.tsv", "model_id")),
                 Relation.betweenTableColumns(
                         Relation.validityType.one_to_one,
                         ColumnReference.of("metadata-sample.tsv", "sample_id"),

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/Relation.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/Relation.java
@@ -4,30 +4,50 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public class Relation {
+
+    private validityType validity;
     private String leftTableName;
     private String leftColumnName;
     private String rightTableName;
     private String rightColumnName;
 
+    public enum validityType {
+        table_key,
+        one_to_one,
+        one_to_many,
+    }
+
     private Relation(
-        String leftTableName,
-        String leftColumnName,
-        String rightTableName,
-        String rightColumnName
-    ) {
+            validityType validity,
+            String leftTableName,
+            String leftColumnName,
+            String rightTableName,
+            String rightColumnName
+    ){
+        this.validity = validity;
         this.leftTableName = leftTableName;
         this.leftColumnName = leftColumnName;
         this.rightTableName = rightTableName;
         this.rightColumnName = rightColumnName;
     }
 
-    public static Relation between(ColumnReference left, ColumnReference right) {
+    public static Relation betweenTableKeys(ColumnReference left, ColumnReference right) {
         if (left.equals(right))
             throw new IllegalArgumentException(
                 String.format("Unable to define a relation from a column to itself (%s)", left));
 
-        return new Relation(left.table(), left.column(), right.table(), right.column());
+        return new Relation(validityType.table_key, left.table(), left.column(), right.table(), right.column());
     }
+
+    public static Relation betweenTableColumns(validityType plurality, ColumnReference left,
+                                               ColumnReference right){
+        if (left.equals(right))
+            throw new IllegalArgumentException(
+                    String.format("Unable to define a relation from a column to itself (%s)", left));
+
+        return new Relation(plurality, left.table(), left.column(), right.table(), right.column());
+    }
+
 
     public ColumnReference getOtherColumn(ColumnReference queriedColumn) {
         ColumnReference otherColumn;
@@ -66,6 +86,11 @@ public class Relation {
         return ColumnReference.of(rightTable(), rightColumn());
     }
 
+    public validityType getValidity() { return validity; }
+
+    public void setValidity(validityType validity) { this.validity = validity; }
+
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -85,6 +110,7 @@ public class Relation {
     @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
+            .append(validity)
             .append(leftTableName)
             .append(leftColumnName)
             .append(rightTableName)
@@ -99,7 +125,8 @@ public class Relation {
             leftTableName,
             leftColumnName,
             rightColumnName,
-            rightTableName);
+            rightTableName
+        );
     }
 
 }

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/Validator.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/Validator.java
@@ -18,18 +18,19 @@ public class Validator {
     private List<ValidationError> validationErrors;
     private MissingTableErrorCreator missingTableErrorCreator;
 
-    public Validator(
-        MissingTableErrorCreator missingTableErrorCreator
-    ) {
+    public Validator(MissingTableErrorCreator missingTableErrorCreator) {
         this.missingTableErrorCreator = missingTableErrorCreator;
-        clearValidationErrors();
+        this.validationErrors = new ArrayList<>();
+    }
+
+    public Validator() {
+        resetErrors();
     }
 
     public List<ValidationError> validate(
         Map<String, Table> tableSet,
         TableSetSpecification tableSetSpecification
     ) {
-        clearValidationErrors();
         checkRequiredTablesPresent(tableSet, tableSetSpecification);
         performColumnValidations(tableSet, tableSetSpecification);
         return validationErrors;
@@ -115,7 +116,8 @@ public class Validator {
             log.info("There were no validation errors raised, great!");
     }
 
-    private void clearValidationErrors(){
+    public void resetErrors(){
+        this.missingTableErrorCreator = new MissingTableErrorCreator();
         this.validationErrors = new ArrayList<>();
     }
 

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/Validator.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/Validator.java
@@ -22,13 +22,14 @@ public class Validator {
         MissingTableErrorCreator missingTableErrorCreator
     ) {
         this.missingTableErrorCreator = missingTableErrorCreator;
-        this.validationErrors = new ArrayList<>();
+        clearValidationErrors();
     }
 
     public List<ValidationError> validate(
         Map<String, Table> tableSet,
         TableSetSpecification tableSetSpecification
     ) {
+        clearValidationErrors();
         checkRequiredTablesPresent(tableSet, tableSetSpecification);
         performColumnValidations(tableSet, tableSetSpecification);
         return validationErrors;
@@ -112,6 +113,10 @@ public class Validator {
             }
         else
             log.info("There were no validation errors raised, great!");
+    }
+
+    private void clearValidationErrors(){
+        this.validationErrors = new ArrayList<>();
     }
 
 }

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/error/BrokenRelationError.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/error/BrokenRelationError.java
@@ -36,9 +36,10 @@ public class BrokenRelationError implements ValidationError {
     @Override
     public String message() {
         return String.format(
-            "Error in [%s] for provider [%s]: Broken relation [%s]: %s",
+            "Error in [%s] for provider [%s]: Broken %s relation [%s]: %s",
             tableName,
             provider,
+            relation.getValidity().name(),
             relation,
             description
         );

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/error/BrokenRelationErrorCreator.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/tablevalidation/error/BrokenRelationErrorCreator.java
@@ -106,7 +106,7 @@ public class BrokenRelationErrorCreator extends ErrorCreator {
 
     private int[] indicesOf(StringColumn column, String search) {
         return IntStream.range(0, column.size())
-                .filter((i) -> column.get(i).equals(search))
+                .filter(i -> column.get(i).equals(search))
                 .toArray();
     }
 
@@ -135,7 +135,7 @@ public class BrokenRelationErrorCreator extends ErrorCreator {
                 .map(columnPairs::get)
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
-        if (listOfBrokenPairs.size() > 0) {
+        if (!listOfBrokenPairs.isEmpty()) {
             int[] invalidRows = unboxSet(
                     getIndexOfDuplicatedColumnValues(oneRestrictedColumn)
         );

--- a/indexer/src/test/java/org/pdxfinder/dataloaders/updog/UpdogTest.java
+++ b/indexer/src/test/java/org/pdxfinder/dataloaders/updog/UpdogTest.java
@@ -9,21 +9,14 @@ import org.pdxfinder.dataloaders.updog.domainobjectcreation.DomainObjectCreator;
 import org.pdxfinder.dataloaders.updog.tablevalidation.ColumnReference;
 import org.pdxfinder.dataloaders.updog.tablevalidation.Relation;
 import org.pdxfinder.dataloaders.updog.tablevalidation.TableSetSpecification;
-import org.pdxfinder.dataloaders.updog.tablevalidation.error.ValidationError;
 import org.pdxfinder.dataloaders.updog.tablevalidation.Validator;
+import org.pdxfinder.dataloaders.updog.tablevalidation.error.ValidationError;
 import tech.tablesaw.api.Table;
 
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 import static org.pdxfinder.dataloaders.updog.TableSetUtilities.concatenate;
@@ -147,19 +140,19 @@ public class UpdogTest {
             .addNonEmptyColumns(columnReference2)
             .addUniqueColumns(columnReference1)
             .addUniqueColumns(columnReference2)
-            .addRelations(Relation.between(columnReference1, columnReference2));
+            .addRelations(Relation.betweenTableKeys(columnReference1, columnReference2));
         TableSetSpecification specification1 =  TableSetSpecification.create().setProvider("provider")
             .addRequiredTables(requiredTables1)
             .addRequiredColumns(columnReference1)
             .addNonEmptyColumns(columnReference1)
             .addUniqueColumns(columnReference1)
-            .addRelations(Relation.between(columnReference1, columnReference2));
+            .addRelations(Relation.betweenTableKeys(columnReference1, columnReference2));
         TableSetSpecification specfication2 =  TableSetSpecification.create().setProvider("provider")
             .addRequiredTables(requiredTables2)
             .addRequiredColumns(columnReference2)
             .addNonEmptyColumns(columnReference2)
             .addUniqueColumns(columnReference2)
-            .addRelations(Relation.between(columnReference1, columnReference2));
+            .addRelations(Relation.betweenTableKeys(columnReference1, columnReference2));
         assertEquals(
             expected,
             Updog.merge(specification1, specfication2)

--- a/indexer/src/test/java/org/pdxfinder/dataloaders/updog/tablevalidation/RelationTest.java
+++ b/indexer/src/test/java/org/pdxfinder/dataloaders/updog/tablevalidation/RelationTest.java
@@ -7,10 +7,10 @@ import java.util.Map;
 
 import static org.junit.Assert.*;
 
-public class RelationTest {
+public class  RelationTest {
 
     private Relation createRelation() {
-        return (Relation.between(
+        return (Relation.betweenTableKeys(
                 ColumnReference.of("table1", "join_column"),
                 ColumnReference.of("table2", "join_column")));
     }
@@ -33,7 +33,7 @@ public class RelationTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void between_givenSelfRelationCreated_throwException() {
-        Relation.between(
+        Relation.betweenTableKeys(
             ColumnReference.of("x", "x"),
             ColumnReference.of("x", "x"));
     }
@@ -64,7 +64,7 @@ public class RelationTest {
     }
 
     @Test public void toString_returnsExpectedFormat() {
-        Relation relation =  Relation.between(
+        Relation relation =  Relation.betweenTableKeys(
             ColumnReference.of("foo.tsv", "foo_id"),
             ColumnReference.of("bar.tsv", "bar_id")
         );
@@ -76,47 +76,47 @@ public class RelationTest {
 
 
     @Test public void equals_givenIdenticalObjects_symmetricallyEqual() {
-        Relation x = Relation.between(
+        Relation x = Relation.betweenTableKeys(
             ColumnReference.of("x.tsv", "x"),
             ColumnReference.of("y.tsv", "x"));
-        Relation y = Relation.between(
+        Relation y = Relation.betweenTableKeys(
             ColumnReference.of("x.tsv", "x"),
             ColumnReference.of("y.tsv", "x"));
         assertTrue(x.equals(y) && y.equals(x));
     }
 
     @Test public void equals_givenIdenticalObjects_hashCodeIsEqual() {
-        Relation x = Relation.between(
+        Relation x = Relation.betweenTableKeys(
             ColumnReference.of("x.tsv", "x"),
             ColumnReference.of("y.tsv", "x"));
-        Relation y = Relation.between(
+        Relation y = Relation.betweenTableKeys(
             ColumnReference.of("x.tsv", "x"),
             ColumnReference.of("y.tsv", "x"));
         assertEquals(x.hashCode(), y.hashCode());
     }
 
     @Test public void equals_givenSameObject_returnsTrue() {
-        Relation x = Relation.between(
+        Relation x = Relation.betweenTableKeys(
             ColumnReference.of("x.tsv", "x"),
             ColumnReference.of("y.tsv", "x"));
         assertEquals(x, x);
     }
 
     @Test public void equals_givenNonIdenticalObjects_returnsFalse() {
-        Relation x = Relation.between(
+        Relation x = Relation.betweenTableKeys(
             ColumnReference.of("x.tsv", "x"),
             ColumnReference.of("y.tsv", "x"));
-        Relation y = Relation.between(
+        Relation y = Relation.betweenTableKeys(
             ColumnReference.of("a.tsv", "a"),
             ColumnReference.of("b.tsv", "b"));
         assertNotEquals(x, y);
     }
 
     @Test public void hashCode_givenObjectPutInMap_identicalKeyRetrievesTheValue() {
-        Relation x = Relation.between(
+        Relation x = Relation.betweenTableKeys(
             ColumnReference.of("x.tsv", "x"),
             ColumnReference.of("y.tsv", "x"));
-        Relation y = Relation.between(
+        Relation y = Relation.betweenTableKeys(
             ColumnReference.of("x.tsv", "x"),
             ColumnReference.of("y.tsv", "x"));
         Map<Relation, String> map = new HashMap<>();

--- a/indexer/src/test/java/org/pdxfinder/dataloaders/updog/tablevalidation/error/BrokenRelationErrorCreatorTest.java
+++ b/indexer/src/test/java/org/pdxfinder/dataloaders/updog/tablevalidation/error/BrokenRelationErrorCreatorTest.java
@@ -1,5 +1,6 @@
 package org.pdxfinder.dataloaders.updog.tablevalidation.error;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 import org.pdxfinder.dataloaders.updog.tablevalidation.ColumnReference;
 import org.pdxfinder.dataloaders.updog.tablevalidation.Relation;
@@ -15,127 +16,181 @@ import static org.junit.Assert.assertThat;
 
 public class BrokenRelationErrorCreatorTest {
 
-    private BrokenRelationErrorCreator brokenRelationErrorCreator = new BrokenRelationErrorCreator();
+    private BrokenRelationErrorCreator brokenInterTableRelationErrorCreator = new BrokenRelationErrorCreator();
 
     private final String LEFT_TABLE = "left_table.tsv";
     private final String RIGHT_TABLE = "right_table.tsv";
-    private final Relation RELATION = Relation.between(
-        ColumnReference.of(LEFT_TABLE, "id"),
-        ColumnReference.of(RIGHT_TABLE, "table_1_id")
+    private final String LEFT_TABLE_COLUMN2 = "table_column2";
+    private final Relation INTER_TABLE_RELATION = Relation.betweenTableKeys(
+            ColumnReference.of(LEFT_TABLE, "id"),
+            ColumnReference.of(RIGHT_TABLE, "table_1_id")
     );
+
+    private final Relation INTRA_TABLE_RELATION = Relation.betweenTableColumns(
+            Relation.validityType.one_to_many,
+            ColumnReference.of(LEFT_TABLE, "id"),
+            ColumnReference.of(LEFT_TABLE, "table_1_id")
+    );
+
     private final String PROVIDER = "PROVIDER-BC";
 
     private Map<String, Table> makeTableSetWithSimpleJoin() {
         Table leftTable = Table.create(LEFT_TABLE).addColumns(
-            StringColumn.create("id", Collections.singletonList("1")));
+                StringColumn.create("id", Collections.singletonList("1")));
         Table rightTable = Table.create(RIGHT_TABLE).addColumns(
-            StringColumn.create("table_1_id", Collections.singletonList("1")));
+                StringColumn.create("table_1_id", Collections.singletonList("1")));
         Map<String, Table> tableSetWithSimpleJoin = new HashMap<>();
         tableSetWithSimpleJoin.put(LEFT_TABLE, leftTable);
         tableSetWithSimpleJoin.put(RIGHT_TABLE, rightTable);
         return tableSetWithSimpleJoin;
     }
 
+    private Map<String, Table> makeTableSetWithIntraTableRelations() {
+        Table leftTable = Table.create(LEFT_TABLE).addColumns(
+                StringColumn.create("id", Arrays.asList("1", "2", "3")),
+                StringColumn.create("table_1_id", Arrays.asList("1","1","1"))
+        );
+        Map<String, Table> tableSetWithManyToOne = new HashMap<>();
+        tableSetWithManyToOne.put(LEFT_TABLE, leftTable);
+        return tableSetWithManyToOne;
+    }
+
+    private Map<String, Table> makeTableSetWithBrokenIntraTableRelations() {
+        Table leftTable = Table.create(LEFT_TABLE).addColumns(
+                StringColumn.create("id", Arrays.asList("1","1","1")),
+                StringColumn.create("table_1_id", Arrays.asList("1", "2", "3"))
+        );
+        Map<String, Table> tableSetWithManyToOne = new HashMap<>();
+        tableSetWithManyToOne.put(LEFT_TABLE, leftTable);
+        return tableSetWithManyToOne;
+    }
+
+
     private final TableSetSpecification SIMPLE_JOIN_SPECIFICATION = TableSetSpecification.create().setProvider(PROVIDER)
-        .addRelations(RELATION);
+            .addRelations(INTER_TABLE_RELATION);
+
+    private final TableSetSpecification ONE_TO_MANY_SPECIFICATION = TableSetSpecification.create().setProvider(PROVIDER)
+            .addRelations(INTRA_TABLE_RELATION);
 
     @Test(expected = Test.None.class)
     public void checkRelationsValid_givenNoRightTable_noExceptionThrown() {
         Map<String, Table> tableSetWithSimpleJoin = makeTableSetWithSimpleJoin();
         tableSetWithSimpleJoin.put(RIGHT_TABLE, null);
-        assertThat(brokenRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).isEmpty(),
-            is(true));
+        assertThat(brokenInterTableRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).isEmpty(),
+                is(true));
     }
 
     @Test(expected = Test.None.class)
     public void checkRelationsValid_givenNoLeftTable_noExceptionThrown() {
         Map<String, Table> tableSetWithSimpleJoin = makeTableSetWithSimpleJoin();
         tableSetWithSimpleJoin.put(LEFT_TABLE, null);
-        assertThat(brokenRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).isEmpty(),
-            is(true));
+        assertThat(brokenInterTableRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).isEmpty(),
+                is(true));
     }
 
-    @Test public void checkRelationsValid_givenValidOneToManyJoin_emptyErrorList() {
-        Map<String, Table> tableSetWithSimpleJoin = makeTableSetWithSimpleJoin();
-
-        assertThat(brokenRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).isEmpty(),
-            is(true));
+    @Test(expected = Test.None.class)
+    public void oneToManyNoError_givenValidOneToManyJoin_emptyErrorList() {
+        Map<String, Table> tableSetWithOneToMany = makeTableSetWithIntraTableRelations();
+        assertThat(brokenInterTableRelationErrorCreator.generateErrors(tableSetWithOneToMany, ONE_TO_MANY_SPECIFICATION).isEmpty(),
+                is(true));
     }
 
-    @Test public void checkRelationsValid_givenNoLeftTable_ErrorListWithMissingRequiredCol() {
+    @Test(expected = Test.None.class)
+    public void oneToManyError_givenInvalidValidOneToManyJoin_hasErrorEntry() {
+        Map<String, Table> tableSetWithOneToMany = makeTableSetWithBrokenIntraTableRelations();
+        assertThat(brokenInterTableRelationErrorCreator.generateErrors(tableSetWithOneToMany, ONE_TO_MANY_SPECIFICATION).isEmpty(),
+                is(false));
+    }
+
+    @Test
+    public void checkRelationsValid_givenNoLeftTable_ErrorListWithMissingRequiredCol() {
         Map<String, Table> tableSetWithSimpleJoin = makeTableSetWithSimpleJoin();
         tableSetWithSimpleJoin.get(LEFT_TABLE).removeColumns("id");
 
-        BrokenRelationError expected = brokenRelationErrorCreator.create(
-            LEFT_TABLE, RELATION, tableSetWithSimpleJoin.get(LEFT_TABLE).emptyCopy(),
-            String.format("because [%s] is missing column [%s]", LEFT_TABLE, "id"), PROVIDER);
+        BrokenRelationError expected = brokenInterTableRelationErrorCreator.create(
+                LEFT_TABLE, INTER_TABLE_RELATION, tableSetWithSimpleJoin.get(LEFT_TABLE).emptyCopy(),
+                String.format("because [%s] is missing column [%s]", LEFT_TABLE, "id"), PROVIDER);
 
         assertEquals(
-            Collections.singletonList(expected).toString(),
-            brokenRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).toString()
+                Collections.singletonList(expected).toString(),
+                brokenInterTableRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).toString()
         );
     }
 
-    @Test public void checkRelationsValid_givenNoRightTable_ErrorListWithMissingRequiredCol() {
+    @Test
+    public void checkRelationsValid_givenNoRightTable_ErrorListWithMissingRequiredCol() {
         Map<String, Table> tableSetWithSimpleJoin = makeTableSetWithSimpleJoin();
         tableSetWithSimpleJoin.get(RIGHT_TABLE).removeColumns("table_1_id");
 
-        BrokenRelationError expected = brokenRelationErrorCreator.create(
-            RIGHT_TABLE, RELATION, tableSetWithSimpleJoin.get(RIGHT_TABLE).emptyCopy(),
-            String.format("because [%s] is missing column [%s]", RIGHT_TABLE, "table_1_id"), PROVIDER);
+        BrokenRelationError expected = brokenInterTableRelationErrorCreator.create(
+                RIGHT_TABLE, INTER_TABLE_RELATION, tableSetWithSimpleJoin.get(RIGHT_TABLE).emptyCopy(),
+                String.format("because [%s] is missing column [%s]", RIGHT_TABLE, "table_1_id"), PROVIDER);
 
         assertEquals(
-            Collections.singletonList(expected).toString(),
-            brokenRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).toString()
+                Collections.singletonList(expected).toString(),
+                brokenInterTableRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).toString()
         );
     }
 
-    @Test public void checkRelationsValid_givenMissingValueInRightColumn_ErrorListWithOrphanLeftRows() {
+    @Test
+    public void checkRelationsValid_givenMissingValueInRightColumn_ErrorListWithOrphanLeftRows() {
         Map<String, Table> tableSetWithSimpleJoin = makeTableSetWithSimpleJoin();
         tableSetWithSimpleJoin.get(RIGHT_TABLE).replaceColumn(
-            StringColumn.create("table_1_id", Collections.EMPTY_LIST));
-        BrokenRelationError expected = brokenRelationErrorCreator.create(
-            RIGHT_TABLE, RELATION, tableSetWithSimpleJoin.get(LEFT_TABLE),
-            String.format("1 orphan row(s) found in [%s]", LEFT_TABLE), PROVIDER);
+                StringColumn.create("table_1_id", Collections.EMPTY_LIST));
+        BrokenRelationError expected = brokenInterTableRelationErrorCreator.create(
+                RIGHT_TABLE, INTER_TABLE_RELATION, tableSetWithSimpleJoin.get(LEFT_TABLE),
+                String.format("1 orphan row(s) found in [%s]", LEFT_TABLE), PROVIDER);
 
         assertEquals(
-            Collections.singletonList(expected).toString(),
-            brokenRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).toString()
+                Collections.singletonList(expected).toString(),
+                brokenInterTableRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).toString()
         );
     }
 
-    @Test public void checkRelationsValid_givenMissingValuesInLeftColumn_ErrorListWithOrphanRightRows() {
+    @Test
+    public void checkRelationsValid_givenMissingValuesInLeftColumn_ErrorListWithOrphanRightRows() {
         Map<String, Table> tableSetWithSimpleJoin = makeTableSetWithSimpleJoin();
         tableSetWithSimpleJoin.get(LEFT_TABLE).replaceColumn(
-            StringColumn.create("id", Collections.EMPTY_LIST));
-        BrokenRelationError expected = brokenRelationErrorCreator.create(
-            LEFT_TABLE, RELATION, tableSetWithSimpleJoin.get(RIGHT_TABLE),
-            String.format("1 orphan row(s) found in [%s]", RIGHT_TABLE), PROVIDER
+                StringColumn.create("id", Collections.EMPTY_LIST));
+        BrokenRelationError expected = brokenInterTableRelationErrorCreator.create(
+                LEFT_TABLE, INTER_TABLE_RELATION, tableSetWithSimpleJoin.get(RIGHT_TABLE),
+                String.format("1 orphan row(s) found in [%s]", RIGHT_TABLE), PROVIDER
         );
 
         assertEquals(
-            Collections.singletonList(expected).toString(),
-            brokenRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).toString()
+                Collections.singletonList(expected).toString(),
+                brokenInterTableRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).toString()
         );
     }
 
-    @Test public void checkRelationsValid_givenMissingValueInLeftAndRightColumn_ErrorListWithMissingValueRows() {
+    @Test
+    public void checkRelationsValid_givenMissingValueInLeftAndRightColumn_ErrorListWithMissingValueRows() {
         Map<String, Table> tableSetWithSimpleJoin = makeTableSetWithSimpleJoin();
         tableSetWithSimpleJoin.get(RIGHT_TABLE).replaceColumn(
-            StringColumn.create("table_1_id", Arrays.asList("not 1", "not 1"))
+                StringColumn.create("table_1_id", Arrays.asList("not 1", "not 1"))
         );
         List<ValidationError> expected = Arrays.asList(
-            brokenRelationErrorCreator.create(RIGHT_TABLE, RELATION, tableSetWithSimpleJoin.get(LEFT_TABLE),
-                String.format("1 orphan row(s) found in [%s]", LEFT_TABLE), PROVIDER),
-            brokenRelationErrorCreator.create(LEFT_TABLE, RELATION, tableSetWithSimpleJoin.get(RIGHT_TABLE),
-                String.format("2 orphan row(s) found in [%s]", RIGHT_TABLE), PROVIDER)
+                brokenInterTableRelationErrorCreator.create(RIGHT_TABLE, INTER_TABLE_RELATION, tableSetWithSimpleJoin.get(LEFT_TABLE),
+                        String.format("1 orphan row(s) found in [%s]", LEFT_TABLE), PROVIDER),
+                brokenInterTableRelationErrorCreator.create(LEFT_TABLE, INTER_TABLE_RELATION, tableSetWithSimpleJoin.get(RIGHT_TABLE),
+                        String.format("2 orphan row(s) found in [%s]", RIGHT_TABLE), PROVIDER)
         );
 
         assertEquals(
-            expected.toString(),
-            brokenRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).toString()
+                expected.toString(),
+                brokenInterTableRelationErrorCreator.generateErrors(tableSetWithSimpleJoin, SIMPLE_JOIN_SPECIFICATION).toString()
         );
     }
 
-
+    @Test
+    public void checkToString_GivenIdenticalPairs_hashesMatch() {
+        List<String> columnValuesLeft = Arrays.asList("value1", "value2", "value3");
+        List<String> columnValuesRight = Arrays.asList("value4", "value5", "value6");
+        StringColumn column1 = StringColumn.create("column1", columnValuesLeft);
+        StringColumn column2 = StringColumn.create("column2", columnValuesRight);
+        Pair<StringColumn, StringColumn> pair1 = Pair.of(column1, column2);
+        Pair<StringColumn, StringColumn> pair2 = Pair.of(column1, column2);
+        assertEquals(pair1, pair2);
+        assertEquals(pair1.toString(), pair2.toString());
+    }
 }

--- a/indexer/src/test/java/org/pdxfinder/dataloaders/updog/tablevalidation/error/BrokenRelationErrorTest.java
+++ b/indexer/src/test/java/org/pdxfinder/dataloaders/updog/tablevalidation/error/BrokenRelationErrorTest.java
@@ -8,22 +8,22 @@ import tech.tablesaw.api.Table;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class BrokenRelationErrorTest {
-    private BrokenRelationErrorCreator brokenRelationErrorCreator = new BrokenRelationErrorCreator();
+    private BrokenRelationErrorCreator brokenTableRelationErrorCreator = new BrokenRelationErrorCreator();
 
     @Test public void toString_givenBrokenRelationMissingRightColumn_returnsAppropriateMessage() {
         String expected =
-            "Error in [bar.tsv] for provider [TEST]: Broken relation [(foo.tsv) foo_id -> foo_id (bar.tsv)]" +
+            "Error in [bar.tsv] for provider [TEST]: Broken table_key relation [(foo.tsv) foo_id -> foo_id (bar.tsv)]" +
                 ": because [bar.tsv] is missing column [foo_id]:\n" +
                 " not_foo_id  |\n" +
                 "--------------";
-        Relation relation = Relation.between(
+        Relation relation = Relation.betweenTableKeys(
             ColumnReference.of("foo.tsv", "foo_id"),
             ColumnReference.of("bar.tsv", "foo_id"));
         Table tableMissingColumn = Table.create().addColumns(StringColumn.create("not_foo_id"));
-        BrokenRelationError error = brokenRelationErrorCreator.create(
+        BrokenRelationError error = brokenTableRelationErrorCreator.create(
             "bar.tsv",
             relation,
             tableMissingColumn,
@@ -41,18 +41,18 @@ public class BrokenRelationErrorTest {
     @Test public void verboseMessage_givenBrokenRelationOrphanIdsInRightColumn_returnsAppropriateMessage() {
         String expected =
             "Error in [bar.tsv] for provider [PROVIDER-BC]: " +
-                "Broken relation [(foo.tsv) foo_id -> foo_id (bar.tsv)]: " +
+                "Broken table_key relation [(foo.tsv) foo_id -> foo_id (bar.tsv)]: " +
                 "2 orphan row(s) found in [bar.tsv]:\n" +
                 " foo_id  |\n" +
                 "----------\n" +
                 "      1  |\n" +
                 "      1  |";
-        Relation relation = Relation.between(
+        Relation relation = Relation.betweenTableKeys(
             ColumnReference.of("foo.tsv", "foo_id"),
             ColumnReference.of("bar.tsv", "foo_id"));
         Table tableMissingValues = Table.create().addColumns(
             StringColumn.create("foo_id", Arrays.asList("1", "1")));
-        BrokenRelationError error = brokenRelationErrorCreator.create(
+        BrokenRelationError error = brokenTableRelationErrorCreator.create(
             "bar.tsv",
             relation,
             tableMissingValues,
@@ -69,14 +69,14 @@ public class BrokenRelationErrorTest {
     @Test public void message_givenError_returnsAppropriateMessage() {
         String expected =
             "Error in [bar.tsv] for provider [PROVIDER-BC]: " +
-                "Broken relation [(foo.tsv) foo_id -> foo_id (bar.tsv)]: " +
+                "Broken table_key relation [(foo.tsv) foo_id -> foo_id (bar.tsv)]: " +
                 "2 orphan row(s) found in [bar.tsv]";
-        Relation relation = Relation.between(
+        Relation relation = Relation.betweenTableKeys(
             ColumnReference.of("foo.tsv", "foo_id"),
             ColumnReference.of("bar.tsv", "foo_id"));
         Table tableMissingValues = Table.create().addColumns(
             StringColumn.create("foo_id", Arrays.asList("1", "1")));
-        BrokenRelationError error = brokenRelationErrorCreator.create(
+        BrokenRelationError error = brokenTableRelationErrorCreator.create(
             "bar.tsv",
             relation,
             tableMissingValues,
@@ -88,5 +88,4 @@ public class BrokenRelationErrorTest {
             error.message()
         );
     }
-
 }

--- a/indexer/src/test/java/org/pdxfinder/dataloaders/updog/tablevalidation/error/DuplicateValueErrorCreatorTest.java
+++ b/indexer/src/test/java/org/pdxfinder/dataloaders/updog/tablevalidation/error/DuplicateValueErrorCreatorTest.java
@@ -9,16 +9,13 @@ import org.pdxfinder.dataloaders.updog.tablevalidation.TableSetSpecification;
 import tech.tablesaw.api.StringColumn;
 import tech.tablesaw.api.Table;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class DuplicateValueErrorCreatorTest {
 
@@ -26,7 +23,7 @@ public class DuplicateValueErrorCreatorTest {
     private final String TABLE_1 = "table_1.tsv";
     private final String LEFT_TABLE = "left_table.tsv";
     private final String RIGHT_TABLE = "right_table.tsv";
-    private final Relation RELATION = Relation.between(
+    private final Relation RELATION = Relation.betweenTableKeys(
         ColumnReference.of(LEFT_TABLE, "id"),
         ColumnReference.of(RIGHT_TABLE, "table_1_id")
     );

--- a/indexer/src/test/java/org/pdxfinder/dataloaders/updog/tablevalidation/error/EmptyValueErrorCreatorTest.java
+++ b/indexer/src/test/java/org/pdxfinder/dataloaders/updog/tablevalidation/error/EmptyValueErrorCreatorTest.java
@@ -23,7 +23,7 @@ public class EmptyValueErrorCreatorTest {
     private final String TABLE_1 = "table_1.tsv";
     private final String LEFT_TABLE = "left_table.tsv";
     private final String RIGHT_TABLE = "right_table.tsv";
-    private final Relation RELATION = Relation.between(
+    private final Relation RELATION = Relation.betweenTableKeys(
         ColumnReference.of(LEFT_TABLE, "id"),
         ColumnReference.of(RIGHT_TABLE, "table_1_id")
     );


### PR DESCRIPTION
Iteration to increase rule coverage on metadata. These commit add "types" or relations including:
one-to-one,
one-to-many,
table_key

one-to-one and one-to-many allows the two different columns ( same table, different columns ) relations to be validate. If there are errors the pair of columns are printed. The table_key is the previous implementation of relation ( different table, same column id's)

The duplications for many of the ID's in PDX Validation Ruleset were disabled because they are not "ERRORS". 