### PR TITLE
Removed race variables from PatientDT. Fix casing bug

### DIFF
--- a/data-services/src/main/java/org/pdxfinder/services/DetailsService.java
+++ b/data-services/src/main/java/org/pdxfinder/services/DetailsService.java
@@ -1,19 +1,54 @@
 package org.pdxfinder.services;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.join;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
-import org.pdxfinder.graph.dao.*;
-import org.pdxfinder.graph.repositories.*;
-import org.pdxfinder.services.dto.*;
+import org.pdxfinder.graph.dao.ExternalUrl;
+import org.pdxfinder.graph.dao.Group;
+import org.pdxfinder.graph.dao.MarkerAssociation;
+import org.pdxfinder.graph.dao.ModelCreation;
+import org.pdxfinder.graph.dao.MolecularCharacterization;
+import org.pdxfinder.graph.dao.MolecularData;
+import org.pdxfinder.graph.dao.Patient;
+import org.pdxfinder.graph.dao.PatientSnapshot;
+import org.pdxfinder.graph.dao.Platform;
+import org.pdxfinder.graph.dao.QualityAssurance;
+import org.pdxfinder.graph.dao.Sample;
+import org.pdxfinder.graph.dao.Specimen;
+import org.pdxfinder.graph.dao.TreatmentComponent;
+import org.pdxfinder.graph.dao.TreatmentProtocol;
+import org.pdxfinder.graph.dao.TreatmentSummary;
+import org.pdxfinder.graph.repositories.ModelCreationRepository;
+import org.pdxfinder.graph.repositories.MolecularCharacterizationRepository;
+import org.pdxfinder.graph.repositories.PatientRepository;
+import org.pdxfinder.graph.repositories.PlatformRepository;
+import org.pdxfinder.graph.repositories.SampleRepository;
+import org.pdxfinder.graph.repositories.SpecimenRepository;
+import org.pdxfinder.graph.repositories.TreatmentSummaryRepository;
+import org.pdxfinder.services.dto.DetailsDTO;
+import org.pdxfinder.services.dto.DrugSummaryDTO;
+import org.pdxfinder.services.dto.EngraftmentDataDTO;
+import org.pdxfinder.services.dto.MolecularDataEntryDTO;
+import org.pdxfinder.services.dto.MolecularDataRowDTO;
+import org.pdxfinder.services.dto.MolecularDataTableDTO;
+import org.pdxfinder.services.dto.PatientDTO;
+import org.pdxfinder.services.dto.QualityControlDTO;
 import org.pdxfinder.services.dto.pdxgun.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.*;
-
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.apache.commons.lang3.StringUtils.join;
 
 /*
  * Created by abayomi on 09/05/2018.
@@ -110,12 +145,6 @@ public class DetailsService {
             dto.setAgeAtTimeOfCollection(currentPatientSnapshot.getAgeAtCollection());
         } else {
             dto.setAgeAtTimeOfCollection("Not specified");
-        }
-
-        if (patient.getRace() != null && !patient.getRace().isEmpty()) {
-            dto.setRace(patient.getRace());
-        } else {
-            dto.setRace("Not specified");
         }
 
         if (patient.getEthnicity() != null && !patient.getEthnicity().isEmpty()) {

--- a/data-services/src/main/java/org/pdxfinder/services/PatientService.java
+++ b/data-services/src/main/java/org/pdxfinder/services/PatientService.java
@@ -1,6 +1,15 @@
 package org.pdxfinder.services;
 
-import org.pdxfinder.graph.dao.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.pdxfinder.graph.dao.MarkerAssociation;
+import org.pdxfinder.graph.dao.MolecularCharacterization;
+import org.pdxfinder.graph.dao.MolecularData;
+import org.pdxfinder.graph.dao.Patient;
+import org.pdxfinder.graph.dao.PatientSnapshot;
+import org.pdxfinder.graph.dao.Sample;
+import org.pdxfinder.graph.dao.TreatmentProtocol;
 import org.pdxfinder.graph.repositories.PatientRepository;
 import org.pdxfinder.services.dto.CollectionEventsDTO;
 import org.pdxfinder.services.dto.PatientDTO;
@@ -8,10 +17,6 @@ import org.pdxfinder.services.dto.TreatmentSummaryDTO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
 
 
 @Service
@@ -42,7 +47,7 @@ public class PatientService {
             patientDTO.setDiseaseBodyLocation("Not Available");
             patientDTO.setCTEPSDCCode("Not Available");
             patientDTO.setDiagnosisSubtype("Not Available");
-            patientDTO.setRaceAndEthnicity(patient.getRace()+"/"+patient.getEthnicity());
+            patientDTO.setEthnicity(patient.getEthnicity());
 
             List<String> geneticMutations = new ArrayList<>();
             List<TreatmentSummaryDTO> treatmentSummaries = new ArrayList<>();

--- a/data-services/src/main/java/org/pdxfinder/services/dto/PatientDTO.java
+++ b/data-services/src/main/java/org/pdxfinder/services/dto/PatientDTO.java
@@ -10,7 +10,7 @@ public class PatientDTO {
     private String diseaseBodyLocation;
     private String CTEPSDCCode;
     private String diagnosisSubtype;
-    private String raceAndEthnicity;
+    private String ethnicity;
     private List<TreatmentSummaryDTO> treatmentSummaries;
 
     private Boolean treatmentExists = false;
@@ -30,7 +30,7 @@ public class PatientDTO {
                       String diseaseBodyLocation,
                       String CTEPSDCCode,
                       String diagnosisSubtype,
-                      String raceAndEthnicity,
+                      String ethnicity,
                       List<TreatmentSummaryDTO> treatmentSummaries,
                       Boolean treatmentExists,
                       Boolean currentTreatmentExists,
@@ -41,7 +41,7 @@ public class PatientDTO {
         this.diseaseBodyLocation = diseaseBodyLocation;
         this.CTEPSDCCode = CTEPSDCCode;
         this.diagnosisSubtype = diagnosisSubtype;
-        this.raceAndEthnicity = raceAndEthnicity;
+        this.ethnicity = ethnicity;
         this.treatmentSummaries = treatmentSummaries;
         this.treatmentExists = treatmentExists;
         this.currentTreatmentExists = currentTreatmentExists;
@@ -89,12 +89,12 @@ public class PatientDTO {
         this.diagnosisSubtype = diagnosisSubtype;
     }
 
-    public String getRaceAndEthnicity() {
-        return raceAndEthnicity;
+    public String getEthnicity() {
+        return ethnicity;
     }
 
-    public void setRaceAndEthnicity(String raceAndEthnicity) {
-        this.raceAndEthnicity = raceAndEthnicity;
+    public void setEthnicity(String ethnicity) {
+        this.ethnicity = ethnicity;
     }
 
     public List<String> getKnownGeneticMutations() {

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/TableSetCleaner.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/TableSetCleaner.java
@@ -1,11 +1,10 @@
 package org.pdxfinder.dataloaders.updog;
 
-import org.springframework.stereotype.Service;
-import tech.tablesaw.api.Table;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.springframework.stereotype.Service;
+import tech.tablesaw.api.Table;
 
 @Service
 public class TableSetCleaner {
@@ -16,9 +15,13 @@ public class TableSetCleaner {
                 "sample_id",
                 "patient_id",
                 "name",
+                "host_strain",
+                "host_strain_full",
+                "host_strain_nomenclature",
                 "validation_host_strain_full",
                 "provider_name",
                 "provider_abbreviation",
+                "abbreviation",
                 "project",
                 "internal_url",
                 "internal_dosing_url"

--- a/web/src/main/resources/templates/details.html
+++ b/web/src/main/resources/templates/details.html
@@ -356,10 +356,8 @@
                                             <td th:text="${data.patient.gender}"></td>
                                         </tr>
                                         <tr>
-                                            <th class="text-left medium-4">Race / Ethnicity</th>
+                                            <th class="text-left medium-4">Ethnicity</th>
                                             <td>
-                                                <span th:text="${data.race}"></span>
-                                                <span th:if="${not ( #strings.isEmpty(data.race) || #strings.isEmpty(data.ethnicity) ) }"> / </span>
                                                 <span th:text="${data.ethnicity}"></span>
                                             </td>
                                         </tr>

--- a/web/src/main/resources/templates/patients.html
+++ b/web/src/main/resources/templates/patients.html
@@ -158,8 +158,8 @@
                                             <td th:text="${data.diagnosisSubtype}"></td>
                                         </tr>
                                         <tr>
-                                            <th class="text-left medium-4">Race / Ethnicity</th>
-                                            <td th:text="${data.raceAndEthnicity}"></td>
+                                            <th class="text-left medium-4">Ethnicity</th>
+                                            <td th:text="${data.ethnicity}"></td>
                                         </tr>
                                         </tbody>
                                     </table>


### PR DESCRIPTION
Because:
-- We do not use race in the DB
-- Casing was lower casing multiple strings

* added casing exceptions host_strain, host_strain_full, host_strain_nomenclature, abbreviation
* remove RaceAndEthnicity and replaced with only Ethnicity in PatientDTO
* removed formatting logic for race in DetailsService
* replace call to PatientDTO setter for raceAndEthnicity in DetailsService
* adjust thymleaf logic and presentation of variable.