### PR TITLE
Revert "Change K8_SERVICE_URL to MI pdx-gun instance"

### DIFF
--- a/data-services/src/main/java/org/pdxfinder/services/constants/DataUrl.java
+++ b/data-services/src/main/java/org/pdxfinder/services/constants/DataUrl.java
@@ -9,7 +9,7 @@ public enum DataUrl {
     DISEASES_BRANCH_URL("http://purl.obolibrary.org/obo/NCIT_C3262"),
     ONTOLOGY_URL("https://www.ebi.ac.uk/ols/api/ontologies/ncit/terms/"),
     EUROPE_PMC_URL("https://www.ebi.ac.uk/europepmc/webservices/rest/search"),
-    K8_SERVICE_URL("http://hh-rke-wp-webadmin-20-worker-1.caas.ebi.ac.uk:32763/v1/graphql"),
+    K8_SERVICE_URL("http://193.62.55.22:80/pdx-gun/v1/graphql"),
     COSMIC_URL("https://cancer.sanger.ac.uk/cosmic/mutation/overview?id"),
     CRAVAT_URL("https://run.opencravat.org/result/nocache/variant.html");
 


### PR DESCRIPTION
This reverts commit 3e9165e5

Because:
-- NodePorts on MI Kubernetes are not reachable by production server