### PR TITLE
Remove validator command line options

### DIFF
--- a/indexer/src/main/java/org/pdxfinder/commandline/FinderCommandLine.java
+++ b/indexer/src/main/java/org/pdxfinder/commandline/FinderCommandLine.java
@@ -1,5 +1,14 @@
 package org.pdxfinder.commandline;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.StringJoiner;
+import java.util.concurrent.Callable;
 import org.pdxfinder.services.constants.DataProvider;
 import org.pdxfinder.services.constants.DataProviderGroup;
 import org.pdxfinder.utils.CbpTransformer;
@@ -12,11 +21,6 @@ import picocli.CommandLine;
 import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.Callable;
 
 @Component
 @Command(name = "indexer",
@@ -71,10 +75,6 @@ public class FinderCommandLine implements Callable<Integer> {
                 description = "Delete mapping database content, and reload from mapping file")
         private boolean initializeMappingDB;
 
-        @Option(names = {"--validate-only"},
-                description = "Don't load the PDX data, only perform validation and report errors.")
-        private boolean validateOnlyRequested;
-
         @Option(names = {"-p", "--post-load"},
                 description = "Implement Post data loading Steps")
         private boolean postLoadRequested;
@@ -122,7 +122,6 @@ public class FinderCommandLine implements Callable<Integer> {
             finderLoader.run(
                     providersRequested,
                     dataDirectory,
-                    validateOnlyRequested,
                     loadCacheRequested,
                     postLoadRequested,
                     initializeMappingDB
@@ -154,7 +153,6 @@ public class FinderCommandLine implements Callable<Integer> {
             return new StringJoiner(", ", Load.class.getSimpleName() + "[", "]")
                 .add("dataDirectory=" + dataDirectory)
                 .add("initializeMappingDB=" + initializeMappingDB)
-                .add("validateOnlyRequested=" + validateOnlyRequested)
                 .add("postLoadRequested=" + postLoadRequested)
                 .add("springDataNeo4jUri='" + springDataNeo4jUri + "'")
                 .add("debReload='" + debReload + "'")

--- a/indexer/src/main/java/org/pdxfinder/commandline/FinderLoader.java
+++ b/indexer/src/main/java/org/pdxfinder/commandline/FinderLoader.java
@@ -87,19 +87,17 @@ public class FinderLoader {
     void run(
             List<DataProvider> dataProviders,
             File dataDirectory,
-            boolean validateOnlyRequested,
             boolean loadCacheRequested,
             boolean postLoadRequested,
             boolean initializeMappingDb
     ) {
 
         loadCache(loadCacheRequested);
-        loadRequestedPdxData(dataProviders, dataDirectory, validateOnlyRequested);
-        if (!validateOnlyRequested) {
-            postLoad(dataProviders, postLoadRequested);
-            initializeMappingDb(initializeMappingDb);
+        loadRequestedPdxData(dataProviders, dataDirectory);
+        postLoad(dataProviders, postLoadRequested);
+        initializeMappingDb(initializeMappingDb);
         }
-    }
+
 
     private void loadCache(boolean loadCacheRequested) {
         log.info("Loading cache ...");
@@ -140,23 +138,21 @@ public class FinderLoader {
 
     private void loadRequestedPdxData(
             List<DataProvider> providers,
-            File dataDirectory,
-            boolean validateOnlyRequested
+            File dataDirectory
     ) {
         if (providers.isEmpty()) {
             log.info("Skipping PDX dataset loading - No providers requested");
         } else {
             log.info("Running requested PDX dataset loaders {}...", providers);
             for (DataProvider i : providers)
-                callRelevantLoader(i, dataDirectory, validateOnlyRequested);
+                callRelevantLoader(i, dataDirectory);
         }
     }
 
 
     private void callRelevantLoader(
             DataProvider dataProvider,
-            File dataDirectory,
-            boolean validateOnlyRequested
+            File dataDirectory
     ) {
         List<DataProvider> updogProviders = DataProviderGroup.getProvidersFrom(DataProviderGroup.UPDOG);
         try {
@@ -166,7 +162,7 @@ public class FinderLoader {
                         dataDirectory.toString(),
                         "/data/UPDOG",
                         dataProvider.toString());
-                updog.run(updogDirectory, dataProvider.toString(), validateOnlyRequested);
+                updog.run(updogDirectory, dataProvider.toString());
             }
 
 

--- a/indexer/src/main/java/org/pdxfinder/dataloaders/updog/Updog.java
+++ b/indexer/src/main/java/org/pdxfinder/dataloaders/updog/Updog.java
@@ -29,7 +29,7 @@ public class Updog {
         this.domainObjectCreator = domainObjectCreator;
     }
 
-    public void run(Path updogProviderDirectory, String provider, boolean validateOnly) {
+    public void run(Path updogProviderDirectory, String provider) {
         Map<String, Table> pdxTableSet;
         Map<String, Table> omicsTableSet;
         Map<String, Table> treatmentTableSet;

--- a/indexer/src/test/java/org/pdxfinder/commandline/FinderCommandLineTest.java
+++ b/indexer/src/test/java/org/pdxfinder/commandline/FinderCommandLineTest.java
@@ -1,5 +1,18 @@
 package org.pdxfinder.commandline;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyListOf;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.io.File;
+import java.io.IOException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -8,13 +21,6 @@ import org.mockito.MockitoAnnotations;
 import org.pdxfinder.BaseTest;
 import org.pdxfinder.services.constants.DataProvider;
 import picocli.CommandLine;
-
-import java.io.File;
-import java.io.IOException;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.mockito.Mockito.*;
 
 
 public class FinderCommandLineTest extends BaseTest {
@@ -31,7 +37,7 @@ public class FinderCommandLineTest extends BaseTest {
         doNothing().when(this.finderLoader).run(
                 anyListOf(DataProvider.class),
                 any(File.class),
-                anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean()
+                anyBoolean(), anyBoolean(), anyBoolean()
         );
     }
 
@@ -42,7 +48,7 @@ public class FinderCommandLineTest extends BaseTest {
         verify(this.finderLoader).run(
                 anyList(),
                 any(File.class),
-                anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean()
+                anyBoolean(), anyBoolean(), anyBoolean()
         );
         verifyNoMoreInteractions(this.finderLoader);
     }
@@ -54,7 +60,7 @@ public class FinderCommandLineTest extends BaseTest {
         verify(this.finderLoader).run(
                 anyList(),
                 any(File.class),
-                anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean()
+                anyBoolean(), anyBoolean(), anyBoolean()
         );
         verifyNoMoreInteractions(this.finderLoader);
     }

--- a/indexer/src/test/java/org/pdxfinder/commandline/FinderLoaderTest.java
+++ b/indexer/src/test/java/org/pdxfinder/commandline/FinderLoaderTest.java
@@ -1,5 +1,17 @@
 package org.pdxfinder.commandline;
 
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -20,14 +32,6 @@ import org.pdxfinder.services.loader.envload.LoadMarkers;
 import org.pdxfinder.services.loader.envload.LoadNCIT;
 import org.pdxfinder.services.loader.envload.LoadNCITDrugs;
 
-import java.io.File;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collections;
-
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
-
 public class FinderLoaderTest extends BaseTest {
 
     @Mock private LoadDiseaseOntology loadDiseaseOntology;
@@ -39,7 +43,6 @@ public class FinderLoaderTest extends BaseTest {
 
     private DataProvider dataProvider;
     private DataProvider updogDataProvider;
-    private static boolean NO_VALIDATION_ONLY = false;
 
     @Mock private LinkSamplesToNCITTerms linkSamplesToNCITTerms;
     @Mock private LinkTreatmentsToNCITTerms linkTreatmentsToNCITTerms;
@@ -64,7 +67,7 @@ public class FinderLoaderTest extends BaseTest {
         doNothing().when(this.linkTreatmentsToNCITTerms).run();
         doNothing().when(this.createDataProjections).run();
         doNothing().when(this.setDataVisibility).run();
-        doNothing().when(this.updog).run(any(Path.class), anyString(), anyBoolean());
+        doNothing().when(this.updog).run(any(Path.class), anyString());
 
         this.dataProvider = DataProvider.JAX;
         this.updogDataProvider = DataProvider.UOC_BC;
@@ -74,77 +77,74 @@ public class FinderLoaderTest extends BaseTest {
         finderLoader.run(
             Collections.singletonList(updogDataProvider),
             dataDirectory,
-            NO_VALIDATION_ONLY,
             isFalse, isFalse, isFalse);
-        verify(this.updog).run(any(Path.class), anyString(), anyBoolean());
+        verify(this.updog).run(any(Path.class), anyString());
         verifyNoMoreInteractions(this.updog);
     }
 
     @Test public void run_givenZeroProviders_callNoLoaders() throws Exception {
         finderLoader.run(Arrays.asList(),
             dataDirectory,
-            NO_VALIDATION_ONLY,
             isFalse, isFalse, isFalse);
-        verify(this.updog, never()).run(any(Path.class), anyString(), anyBoolean());
+        verify(this.updog, never()).run(any(Path.class), anyString());
     }
 
     @Test public void load_givenMarkerCache_skipLoadingMarkers() {
         givenEmptyMarkerCache(isFalse);
-        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory,
-                         NO_VALIDATION_ONLY, isFalse, isFalse, isFalse);
+        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory, isFalse, isFalse, isFalse);
         verify(this.loadMarkers, never()).loadGenes(anyString());
     }
 
     @Test public void load_givenNoMarkerCache_loadMarkers() {
         givenEmptyMarkerCache(isTrue);
-        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory, NO_VALIDATION_ONLY, isFalse, isFalse, isFalse);
+        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory,  isFalse, isFalse, isFalse);
         verify(this.loadMarkers).loadGenes(anyString());
         verifyNoMoreInteractions(this.loadMarkers);
     }
 
     @Test public void load_givenMarkerCacheButReloadRequested_reloadMarkers() {
         givenEmptyMarkerCache(isFalse);
-        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory, NO_VALIDATION_ONLY, isTrue, isFalse, isFalse);
+        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory, isTrue, isFalse, isFalse);
         verify(this.loadMarkers).loadGenes(anyString());
         verifyNoMoreInteractions(this.loadMarkers);
     }
 
     @Test public void load_givenOntologyCache_skipLoadingOntologyTerms() {
         givenEmptyOntologyCache(isFalse);
-        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory, NO_VALIDATION_ONLY, isFalse, isFalse, isFalse);
+        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory, isFalse, isFalse, isFalse);
         verify(this.loadMarkers, never()).loadGenes(anyString());
     }
 
     @Test public void load_givenNoOntologyCache_loadOntologyTerms() {
         givenEmptyOntologyCache(isTrue);
-        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory, NO_VALIDATION_ONLY, isFalse, isFalse, isFalse);
+        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory,  isFalse, isFalse, isFalse);
         verify(this.loadNCIT).loadOntology(DataUrl.DISEASES_BRANCH_URL.get());
         verifyNoMoreInteractions(this.loadNCIT);
     }
 
     @Test public void load_givenOntologyCacheButReloadRequested_reloadOntologyTerms() {
         givenEmptyOntologyCache(isFalse);
-        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory, NO_VALIDATION_ONLY, isTrue, isFalse, isFalse);
+        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory, isTrue, isFalse, isFalse);
         verify(this.loadNCIT).loadOntology(anyString());
         verifyNoMoreInteractions(this.loadNCIT);
     }
 
     @Test public void load_givenOntologyCache_skipLoadingRegimens() {
         givenEmptyOntologyCache(isFalse, "treatment");
-        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory, NO_VALIDATION_ONLY, isFalse, isFalse, isFalse);
+        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory, isFalse, isFalse, isFalse);
         verify(this.loadNCITDrugs, never()).loadRegimens();
     }
 
     @Test public void load_givenNoOntologyCache_loadRegimens() {
         givenEmptyOntologyCache(isTrue, "treatment");
-        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory, NO_VALIDATION_ONLY, isFalse, isFalse, isFalse);
+        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory,isFalse, isFalse, isFalse);
         verify(this.loadNCITDrugs).loadRegimens();
         verifyNoMoreInteractions(this.loadNCITDrugs);
     }
 
     @Test public void load_givenOntologyCacheButReloadRequested_reloadRegimens() {
         givenEmptyOntologyCache(isFalse, "treatment");
-        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory, NO_VALIDATION_ONLY, isTrue, isFalse, isFalse);
+        finderLoader.run(Collections.singletonList(dataProvider), dataDirectory, isTrue, isFalse, isFalse);
         verify(this.loadNCITDrugs).loadRegimens();
         verifyNoMoreInteractions(this.loadNCITDrugs);
     }

--- a/indexer/src/test/java/org/pdxfinder/dataloaders/updog/UpdogTest.java
+++ b/indexer/src/test/java/org/pdxfinder/dataloaders/updog/UpdogTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.pdxfinder.dataloaders.updog.TableSetUtilities.concatenate;
 
@@ -43,26 +42,22 @@ public class UpdogTest {
     }
 
     @Test public void run_whenCalled_readInAllPdxFiles() {
-        updog.run(Paths.get("provider/dir"), "Provider", false);
+        updog.run(Paths.get("provider/dir"), "Provider");
         verify(this.reader).readAllTsvFilesIn(any(), any());
     }
 
     @Test public void run_whenCalled_readInAllTreatmentFiles() {
-        updog.run(Paths.get("provider/dir"), "Provider", false);
+        updog.run(Paths.get("provider/dir"), "Provider");
         verify(this.reader).readAllTreatmentFilesIn(any(), any());
     }
 
 
     @Test public void run_whenCalled_objectsCreated() {
-        updog.run(Paths.get("provider/dir"), "Provider", false);
+        updog.run(Paths.get("provider/dir"), "Provider");
         verify(this.domainObjectCreator).loadDomainObjects(any(), any());
         verifyNoMoreInteractions(this.domainObjectCreator);
     }
 
-    @Test public void run_whenValidationOnlyRequested_doNotRunObjectCreation() {
-        updog.run(Paths.get("provider/dir"), "Provider", true);
-        verifyZeroInteractions(this.domainObjectCreator);
-    }
 
     @Test public void concatenate_whenGivenTwoEmptyLists_returnsEmptyList() {
         List<String> emptyList = Collections.emptyList();


### PR DESCRIPTION
Because:
-- The behavior is no longer needed
-- Test was broken

* Remove ValdiationOnlyRequested arguments/parameters